### PR TITLE
cleanup, fixes and restructure

### DIFF
--- a/Source/UnicodeBrowser/UnicodeBrowser.Build.cs
+++ b/Source/UnicodeBrowser/UnicodeBrowser.Build.cs
@@ -27,7 +27,7 @@ public class UnicodeBrowser : ModuleRules
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core",
+				"Core"
 				// ... add other public dependencies that you statically link with here ...
 			}
 		);

--- a/Source/UnicodeBrowser/UnicodeBrowser.Build.cs
+++ b/Source/UnicodeBrowser/UnicodeBrowser.Build.cs
@@ -27,7 +27,7 @@ public class UnicodeBrowser : ModuleRules
 		PublicDependencyModuleNames.AddRange(
 			new string[]
 			{
-				"Core"
+				"Core",
 				// ... add other public dependencies that you statically link with here ...
 			}
 		);

--- a/Source/UnicodeBrowser/UnicodeBrowserOptions.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserOptions.cpp
@@ -1,0 +1,41 @@
+// all rights reserved
+
+
+#include "UnicodeBrowserOptions.h"
+
+TSharedRef<IDetailsView> UUnicodeBrowserOptions::MakePropertyEditor(UUnicodeBrowserOptions* Options)
+{
+	FPropertyEditorModule& PropertyEditor = FModuleManager::Get().LoadModuleChecked<FPropertyEditorModule>(TEXT("PropertyEditor"));
+	FDetailsViewArgs DetailsViewArgs;
+	DetailsViewArgs.bAllowSearch = false;
+	DetailsViewArgs.bHideSelectionTip = true;
+	DetailsViewArgs.bShowModifiedPropertiesOption = false;
+	DetailsViewArgs.bShowScrollBar = false;
+	DetailsViewArgs.bShowOptions = false;
+	DetailsViewArgs.bShowObjectLabel = false;
+	DetailsViewArgs.bLockable = false;
+	auto FontDetailsView = PropertyEditor.CreateDetailView(DetailsViewArgs);
+	FontDetailsView->SetObject(Options);
+	return FontDetailsView;
+}
+
+void UUnicodeBrowserOptions::PostInitProperties()
+{
+	Super::PostInitProperties();
+	if (!Font.HasValidFont())
+	{
+		Font = FCoreStyle::GetDefaultFontStyle("Regular", 18);
+	}
+}
+
+void UUnicodeBrowserOptions::PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent)
+{
+	Super::PostEditChangeProperty(PropertyChangedEvent);
+
+	if (!Font.HasValidFont())
+	{
+		Font = FCoreStyle::GetDefaultFontStyle("Regular", 18);
+	}
+	
+	OnChanged.Broadcast(&PropertyChangedEvent);
+}

--- a/Source/UnicodeBrowser/UnicodeBrowserOptions.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserOptions.h
@@ -22,11 +22,17 @@ public:
 	UPROPERTY(EditAnywhere)
 	int32 NumCols = 24;
 
+	// Show Characters which can't be displayed by the font (primary for debug purposes)
 	UPROPERTY(EditAnywhere)
 	bool bShowMissing = false;
 
+	// Show Characters which have a measurement of 0x0 (primary for debug purposes)
 	UPROPERTY(EditAnywhere)
 	bool bShowZeroSize = false;
+
+	// Cache the Character meta information while loading the font, this is slower while changing fonts, but may reduce delay for displaying character previews
+	UPROPERTY(EditAnywhere)
+	bool bCacheCharacterMetaOnLoad = false;
 
 	virtual void PostInitProperties() override;
 

--- a/Source/UnicodeBrowser/UnicodeBrowserOptions.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserOptions.h
@@ -1,0 +1,37 @@
+// all rights reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+#include "UnicodeBrowserOptions.generated.h"
+
+/**
+ * 
+ */
+UCLASS(Hidden, BlueprintType, EditInlineNew, DefaultToInstanced, DisplayName = "Font Options")
+class UNICODEBROWSER_API UUnicodeBrowserOptions : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	static TSharedRef<class IDetailsView> MakePropertyEditor(UUnicodeBrowserOptions* Options);
+	UPROPERTY(EditAnywhere, meta=(ShowOnlyInnerProperties), Transient)
+	FSlateFontInfo Font = FCoreStyle::GetDefaultFontStyle("Regular", 18);
+
+	UPROPERTY(EditAnywhere)
+	int32 NumCols = 24;
+
+	UPROPERTY(EditAnywhere)
+	bool bShowMissing = false;
+
+	UPROPERTY(EditAnywhere)
+	bool bShowZeroSize = false;
+
+	virtual void PostInitProperties() override;
+
+	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
+
+	DECLARE_MULTICAST_DELEGATE_OneParam(FOnNumColsChangedDelegate, struct FPropertyChangedEvent*);
+	FOnNumColsChangedDelegate OnChanged;
+};

--- a/Source/UnicodeBrowser/UnicodeBrowserRow.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserRow.h
@@ -1,0 +1,80 @@
+#pragma once
+#include "Fonts/UnicodeBlockRange.h"
+#include "Fonts/FontMeasure.h"
+
+class FUnicodeBrowserRow : public TSharedFromThis<FUnicodeBrowserRow>
+{
+public:
+	FUnicodeBrowserRow(int32 CodePointIn, TOptional<EUnicodeBlockRange> BlockRangeIn, FSlateFontInfo const *FontInfoIn = nullptr) : Codepoint(CodePointIn), BlockRange(BlockRangeIn), FontInfo(FontInfoIn)
+	{		
+		FUnicodeChar::CodepointToString(Codepoint, Character);
+	}
+
+	FString Character;			
+	int32 Codepoint = 0;
+	TOptional<EUnicodeBlockRange> BlockRange;	
+
+private:
+	FSlateFontInfo const *FontInfo = nullptr;
+	const FFontData *FontData = nullptr;
+	TOptional<float> ScalingFactor;
+	TOptional<FVector2D> Measurements;
+	TOptional<bool> bCanLoadCodepoint;
+
+	
+public:	
+	const FFontData* GetFontData()
+	{
+		if(!FontData && FontInfo)
+		{
+			float ScalingFactorResult;
+			FontData = &FSlateApplication::Get().GetRenderer()->GetFontCache()->GetFontDataForCodepoint(*FontInfo, Codepoint, ScalingFactorResult);
+			ScalingFactor = ScalingFactorResult;
+		}
+		
+		return FontData;
+	}
+
+	bool CanLoadCodepoint()
+	{
+		if(!bCanLoadCodepoint.IsSet() && GetFontData()){
+			bCanLoadCodepoint = FSlateApplication::Get().GetRenderer()->GetFontCache()->CanLoadCodepoint(*FontData, Codepoint);			
+		}
+
+		return bCanLoadCodepoint.Get(false);
+	}
+
+	FVector2D GetMeasurements()
+	{
+		if(!Measurements.IsSet() && FontInfo){	
+			Measurements = FSlateApplication::Get().GetRenderer()->GetFontMeasureService()->Measure(*Character, *FontInfo);			
+		}
+
+		return Measurements.Get(FVector2D::ZeroVector);
+	}
+
+	float GetScaling()
+	{
+		if(!ScalingFactor.IsSet())
+		{
+			// this will try to populate the ScalingFactor
+			GetFontData();
+		}
+
+		return ScalingFactor.Get(0.0f);
+	}
+	
+
+	friend bool operator==(FUnicodeBrowserRow const& Lhs, FUnicodeBrowserRow const& RHS)
+	{
+		return Lhs.Codepoint == RHS.Codepoint
+			&& Lhs.Character == RHS.Character
+			&& Lhs.BlockRange == RHS.BlockRange
+			&& Lhs.FontData == RHS.FontData
+			&& Lhs.ScalingFactor == RHS.ScalingFactor
+			&& Lhs.Measurements == RHS.Measurements
+			&& Lhs.bCanLoadCodepoint == RHS.bCanLoadCodepoint;
+	}
+
+	friend bool operator!=(FUnicodeBrowserRow const& Lhs, FUnicodeBrowserRow const& RHS) { return !(Lhs == RHS); }
+};

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
@@ -65,33 +65,6 @@ TArrayView<FUnicodeBlockRange const> UnicodeBrowser::GetUnicodeBlockRanges()
 	return BlockRange;
 }
 
-TArray<EUnicodeBlockRange> UnicodeBrowser::GetSymbolRanges()
-{
-	TArray<EUnicodeBlockRange> SymbolRanges;
-	SymbolRanges.Add(EUnicodeBlockRange::Arrows);
-	SymbolRanges.Add(EUnicodeBlockRange::BlockElements);
-	SymbolRanges.Add(EUnicodeBlockRange::BoxDrawing);
-	SymbolRanges.Add(EUnicodeBlockRange::CurrencySymbols);
-	SymbolRanges.Add(EUnicodeBlockRange::Dingbats);
-	SymbolRanges.Add(EUnicodeBlockRange::EmoticonsEmoji);
-	SymbolRanges.Add(EUnicodeBlockRange::EnclosedAlphanumericSupplement);
-	SymbolRanges.Add(EUnicodeBlockRange::EnclosedAlphanumerics);
-	SymbolRanges.Add(EUnicodeBlockRange::GeneralPunctuation);
-	SymbolRanges.Add(EUnicodeBlockRange::GeometricShapes);
-	SymbolRanges.Add(EUnicodeBlockRange::Latin1Supplement);
-	SymbolRanges.Add(EUnicodeBlockRange::LatinExtendedB);
-	SymbolRanges.Add(EUnicodeBlockRange::MathematicalAlphanumericSymbols);
-	SymbolRanges.Add(EUnicodeBlockRange::MathematicalOperators);
-	SymbolRanges.Add(EUnicodeBlockRange::MiscellaneousMathematicalSymbolsB);
-	SymbolRanges.Add(EUnicodeBlockRange::MiscellaneousSymbols);
-	SymbolRanges.Add(EUnicodeBlockRange::MiscellaneousSymbolsAndArrows);
-	SymbolRanges.Add(EUnicodeBlockRange::MiscellaneousSymbolsAndPictographs);
-	SymbolRanges.Add(EUnicodeBlockRange::MiscellaneousTechnical);
-	SymbolRanges.Add(EUnicodeBlockRange::NumberForms);
-	SymbolRanges.Add(EUnicodeBlockRange::SupplementalSymbolsAndPictographs);
-	SymbolRanges.Add(EUnicodeBlockRange::TransportAndMapSymbols);
-	return SymbolRanges;
-}
 
 TSharedPtr<SUbCheckBoxList> SUnicodeBrowserWidget::MakeRangeSelector()
 {
@@ -246,7 +219,7 @@ void SUnicodeBrowserWidget::MakeRangeWidget(FUnicodeBlockRange const Range)
 FReply SUnicodeBrowserWidget::OnOnlySymbolsClicked()
 {
 	RangeSelector->UncheckAll();
-	for (auto const SymbolRange : UnicodeBrowser::GetSymbolRanges())
+	for (auto const SymbolRange : UnicodeBrowser::SymbolRanges)
 	{
 		int32 const Index = RangeIndices[SymbolRange];
 		RangeSelector->SetItemChecked(Index, ECheckBoxState::Checked);

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
@@ -455,6 +455,13 @@ void SUnicodeBrowserWidget::PopulateSupportedCharacters()
 		for (int CharCode = Range.Range.GetLowerBound().GetValue(); CharCode <= Range.Range.GetUpperBound().GetValue(); ++CharCode)
 		{
 			auto Row = MakeShared<FUnicodeBrowserRow>(CharCode, Range.Index, &Options->Font);
+
+			if(Options->bCacheCharacterMetaOnLoad)
+			{
+				Row->GetMeasurements();
+				Row->CanLoadCodepoint();
+			}
+			
 			if(Options->bShowMissing || Row->CanLoadCodepoint())
 			{
 				RangeArray.Add(Row);

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
@@ -11,7 +11,6 @@
 #include "Components/VerticalBox.h"
 
 #include "Editor/PropertyEditor/Private/Presentation/PropertyEditor/PropertyEditor.h"
-#include "Engine/Font.h"
 
 #include "Fonts/FontMeasure.h"
 #include "Fonts/UnicodeBlockRange.h"

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -21,7 +21,7 @@ namespace UnicodeBrowser
 {
 	inline TOptional<EUnicodeBlockRange> GetUnicodeBlockRangeFromChar(int32 const CharCode);
 
-	inline TArrayView<FUnicodeBlockRange const> GetUnicodeBlockRanges();
+	TArrayView<FUnicodeBlockRange const> GetUnicodeBlockRanges();
 
 	inline int32 GetRangeIndex(EUnicodeBlockRange BlockRange)
 	{
@@ -101,12 +101,18 @@ public:
 
 	void Construct(FArguments const& InArgs);
 
+	
 protected:
+	TMap<uint32, FString> SupportedCharacters;
+	
+	
 	TArray<TSharedPtr<FUnicodeBrowserRow>> Rows;
-	TArray<TSharedPtr<SWidget>> RangeWidgets;
+	TMap<EUnicodeBlockRange, int32> RangeCharacterCount;
+	
+	TMap<EUnicodeBlockRange, TSharedPtr<SExpandableArea>> RangeWidgets;
+	TMap<EUnicodeBlockRange, TSharedPtr<SUniformGridPanel>> RangeWidgetsGrid;
 	TArrayView<FUnicodeBlockRange const> Ranges;
 	TMap<EUnicodeBlockRange const, int32 const> RangeIndices;
-	TMap<uint32, FString> SupportedCharacters;
 	TObjectPtr<UUnicodeBrowserOptions> Options;
 	TSharedPtr<SScrollBox> RangeScrollbox;
 	TSharedPtr<SUbCheckBoxList> RangeSelector;
@@ -124,10 +130,15 @@ protected:
 	FSlateFontInfo GetFont() const;
 	FString GetUnicodeCharacterName(int32 CharCode);
 	TSharedPtr<SUbCheckBoxList> MakeRangeSelector();
-	TSharedPtr<SWidget> MakeRangeWidget(FUnicodeBlockRange Range) const;
+	void MakeRangeWidget(FUnicodeBlockRange Range);
 	void PopulateSupportedCharacters();
 	void RebuildGridColumns(::FUnicodeBlockRange Range, TSharedRef<SUniformGridPanel> const GridPanel) const;
+
+	
+	void UpdateFromFont();
 };
+
+
 class SUnicodeCharacterInfo: public SCompoundWidget
 {
 public:

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -41,8 +41,10 @@ class FUnicodeBrowserRow : public TSharedFromThis<FUnicodeBrowserRow>
 public:
 	FUnicodeBrowserRow() = default;
 
+	FUnicodeBrowserRow(int32 CodePointIn, TOptional<EUnicodeBlockRange> BlockRangeIn) : Codepoint(CodePointIn), BlockRange(BlockRangeIn) {}
+
 	int32 Codepoint = 0;
-	FString Character;
+	FString Character = "";
 	TOptional<EUnicodeBlockRange> BlockRange;
 	FFontData FontData;
 	float ScalingFactor = 1.0f;
@@ -100,19 +102,14 @@ public:
 	SLATE_END_ARGS()
 
 	void Construct(FArguments const& InArgs);
-
 	
 protected:
-	TMap<uint32, FString> SupportedCharacters;
+	TArrayView<FUnicodeBlockRange const> Ranges; // all known unicode ranges
 	
-	
-	TArray<TSharedPtr<FUnicodeBrowserRow>> Rows;
-	TMap<EUnicodeBlockRange, int32> RangeCharacterCount;
-	
+	TMap<EUnicodeBlockRange, TArray<TSharedPtr<FUnicodeBrowserRow>>> Rows;	
 	TMap<EUnicodeBlockRange, TSharedPtr<SExpandableArea>> RangeWidgets;
 	TMap<EUnicodeBlockRange, TSharedPtr<SUniformGridPanel>> RangeWidgetsGrid;
-	TArrayView<FUnicodeBlockRange const> Ranges;
-	TMap<EUnicodeBlockRange const, int32 const> RangeIndices;
+	TMap<EUnicodeBlockRange const, int32 const> RangeIndices; // range <> SUbCheckBoxList index 
 	TObjectPtr<UUnicodeBrowserOptions> Options;
 	TSharedPtr<SScrollBox> RangeScrollbox;
 	TSharedPtr<SUbCheckBoxList> RangeSelector;

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -34,7 +34,30 @@ namespace UnicodeBrowser
 		);
 	}
 
-	static TArray<EUnicodeBlockRange> GetSymbolRanges();
+	static TArray<EUnicodeBlockRange> SymbolRanges {
+		EUnicodeBlockRange::Arrows,
+		EUnicodeBlockRange::BlockElements,
+		EUnicodeBlockRange::BoxDrawing,
+		EUnicodeBlockRange::CurrencySymbols,
+		EUnicodeBlockRange::Dingbats,
+		EUnicodeBlockRange::EmoticonsEmoji,
+		EUnicodeBlockRange::EnclosedAlphanumericSupplement,
+		EUnicodeBlockRange::EnclosedAlphanumerics,
+		EUnicodeBlockRange::GeneralPunctuation,
+		EUnicodeBlockRange::GeometricShapes,
+		EUnicodeBlockRange::Latin1Supplement,
+		EUnicodeBlockRange::LatinExtendedB,
+		EUnicodeBlockRange::MathematicalAlphanumericSymbols,
+		EUnicodeBlockRange::MathematicalOperators,
+		EUnicodeBlockRange::MiscellaneousMathematicalSymbolsB,
+		EUnicodeBlockRange::MiscellaneousSymbols,
+		EUnicodeBlockRange::MiscellaneousSymbolsAndArrows,
+		EUnicodeBlockRange::MiscellaneousSymbolsAndPictographs,
+		EUnicodeBlockRange::MiscellaneousTechnical,
+		EUnicodeBlockRange::NumberForms,
+		EUnicodeBlockRange::SupplementalSymbolsAndPictographs,
+		EUnicodeBlockRange::TransportAndMapSymbols
+	};
 }
 
 class SUnicodeBrowserWidget : public SCompoundWidget

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -34,7 +34,7 @@ namespace UnicodeBrowser
 		);
 	}
 
-	static TArray<EUnicodeBlockRange> SymbolRanges {
+	static TArray<EUnicodeBlockRange> SymbolRanges = {
 		EUnicodeBlockRange::Arrows,
 		EUnicodeBlockRange::BlockElements,
 		EUnicodeBlockRange::BoxDrawing,

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -3,13 +3,14 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "UnicodeBrowserOptions.h"
+#include "UnicodeBrowserRow.h"
 
 #include "Fonts/UnicodeBlockRange.h"
 
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/Views/SListView.h"
 
-#include "UnicodeBrowserWidget.generated.h"
 
 class UFont;
 class SScrollBox;
@@ -36,65 +37,6 @@ namespace UnicodeBrowser
 	static TArray<EUnicodeBlockRange> GetSymbolRanges();
 }
 
-class FUnicodeBrowserRow : public TSharedFromThis<FUnicodeBrowserRow>
-{
-public:
-	FUnicodeBrowserRow() = default;
-
-	FUnicodeBrowserRow(int32 CodePointIn, TOptional<EUnicodeBlockRange> BlockRangeIn) : Codepoint(CodePointIn), BlockRange(BlockRangeIn) {}
-
-	int32 Codepoint = 0;
-	FString Character = "";
-	TOptional<EUnicodeBlockRange> BlockRange;
-	FFontData FontData;
-	float ScalingFactor = 1.0f;
-	FVector2D Measurements;
-	bool bCanLoadCodepoint = false;
-
-	friend bool operator==(FUnicodeBrowserRow const& Lhs, FUnicodeBrowserRow const& RHS)
-	{
-		return Lhs.Codepoint == RHS.Codepoint
-			&& Lhs.Character == RHS.Character
-			&& Lhs.BlockRange == RHS.BlockRange
-			&& Lhs.FontData == RHS.FontData
-			&& Lhs.ScalingFactor == RHS.ScalingFactor
-			&& Lhs.Measurements == RHS.Measurements
-			&& Lhs.bCanLoadCodepoint == RHS.bCanLoadCodepoint;
-	}
-
-	friend bool operator!=(FUnicodeBrowserRow const& Lhs, FUnicodeBrowserRow const& RHS) { return !(Lhs == RHS); }
-};
-
-UCLASS(Hidden, BlueprintType, EditInlineNew, DefaultToInstanced, DisplayName = "Font Options")
-class UNICODEBROWSER_API UUnicodeBrowserOptions : public UObject
-{
-	GENERATED_BODY()
-
-public:
-	static TSharedRef<class IDetailsView> MakePropertyEditor(UUnicodeBrowserOptions* Options);
-	UPROPERTY(EditAnywhere, meta=(ShowOnlyInnerProperties), Transient)
-	FSlateFontInfo Font = FCoreStyle::GetDefaultFontStyle("Regular", 18);
-
-	UPROPERTY(EditAnywhere)
-	int32 NumCols = 24;
-
-	UPROPERTY(EditAnywhere)
-	bool bShowMissing = false;
-
-	UPROPERTY(EditAnywhere)
-	bool bShowZeroSize = false;
-
-	virtual void PostInitProperties() override;
-
-	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;
-
-	DECLARE_MULTICAST_DELEGATE(FOnNumColsChangedDelegate);
-	FOnNumColsChangedDelegate OnChanged;
-};
-
-/**
- * 
- */
 class SUnicodeBrowserWidget : public SCompoundWidget
 {
 public:
@@ -105,7 +47,6 @@ public:
 	
 protected:
 	TArrayView<FUnicodeBlockRange const> Ranges; // all known unicode ranges
-	
 	TMap<EUnicodeBlockRange, TArray<TSharedPtr<FUnicodeBrowserRow>>> Rows;	
 	TMap<EUnicodeBlockRange, TSharedPtr<SExpandableArea>> RangeWidgets;
 	TMap<EUnicodeBlockRange, TSharedPtr<SUniformGridPanel>> RangeWidgetsGrid;
@@ -132,21 +73,6 @@ protected:
 	void RebuildGridColumns(::FUnicodeBlockRange Range, TSharedRef<SUniformGridPanel> const GridPanel) const;
 
 	
-	void UpdateFromFont();
+	void UpdateFromFont(struct FPropertyChangedEvent* PropertyChangedEvent = nullptr);
 };
 
-
-class SUnicodeCharacterInfo: public SCompoundWidget
-{
-public:
-	SLATE_BEGIN_ARGS(SUnicodeCharacterInfo) {}
-		SLATE_ATTRIBUTE(TSharedPtr<FUnicodeBrowserRow>, Row);
-	SLATE_END_ARGS()
-
-	void Construct(FArguments const& InArgs);
-	
-	TAttribute<TSharedPtr<FUnicodeBrowserRow>> Row;
-	TSharedPtr<FUnicodeBrowserRow> GetRow() const;
-	
-	void SetRow(TSharedPtr<FUnicodeBrowserRow> InRow);
-};

--- a/Source/UnicodeBrowser/Widgets/UnicodeCharacterInfo.cpp
+++ b/Source/UnicodeBrowser/Widgets/UnicodeCharacterInfo.cpp
@@ -1,0 +1,113 @@
+// all rights reserved
+
+
+#include "UnicodeCharacterInfo.h"
+
+#include "SlateOptMacros.h"
+#include "UnicodeBrowser/UnicodeBrowserRow.h"
+
+BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
+
+
+void SUnicodeCharacterInfo::Construct(FArguments const& InArgs)
+{
+	Row = InArgs._Row;
+
+	if(!Row.Get()->GetFontData())
+	{
+		// chicken out if the row doesn't have valid FontData (e.g. the dummy which is generated when spawning the Tool Window)
+		return;
+	}
+	
+	ChildSlot
+	[
+		SNew(SVerticalBox)
+		+ SVerticalBox::Slot()
+		[
+			SNew(STextBlock)
+			.Text_Lambda(
+				[this]()
+				{
+					return FText::FromString(FString::Printf(TEXT("Codepoint: 0x%04X"), Row.Get()->Codepoint));
+				}
+			)
+		]
+		+ SVerticalBox::Slot()
+		[
+			SNew(STextBlock)
+			.Text_Lambda(
+				[this]()
+				{
+					return FText::FromString(FString::Printf(TEXT("Can Load: %s"), *LexToString(Row.Get()->CanLoadCodepoint())));
+				}
+			)
+		]
+		+ SVerticalBox::Slot()
+		[
+			SNew(STextBlock)
+			.Text_Lambda(
+				[this]()
+				{
+					return FText::FromString(FString::Printf(TEXT("Size: %s"), *Row.Get()->GetMeasurements().ToString()));
+				}
+			)
+		]
+		+ SVerticalBox::Slot()
+		[
+			SNew(STextBlock)
+			.Text_Lambda(
+				[this]()
+				{
+					if(Row.Get()->GetFontData())
+					{
+						return FText::FromString(FString::Printf(TEXT("Font: %s"), *Row.Get()->GetFontData()->GetFontFilename()));
+					}
+					else
+					{
+						return FText::GetEmpty();
+					}
+				}
+			)
+		]
+		+ SVerticalBox::Slot()
+		[
+			SNew(STextBlock)
+			.Text_Lambda(
+				[this]()
+				{
+					if(Row.Get()->GetFontData())
+					{
+						return FText::FromString(FString::Printf(TEXT("SubFace Index: %d"), Row.Get()->GetFontData()->GetSubFaceIndex()));
+					}
+					else
+					{
+						return FText::GetEmpty();
+					}
+				}
+			)
+		]
+		+ SVerticalBox::Slot()
+		[
+			SNew(STextBlock)
+			.Text_Lambda(
+				[this]()
+				{
+					return FText::FromString(FString::Printf(TEXT("Scaling Factor: %3.3f"), Row.Get()->GetScaling()));
+				}
+			)
+		]
+	];
+}
+
+TSharedPtr<FUnicodeBrowserRow> SUnicodeCharacterInfo::GetRow() const
+{
+	return {};
+}
+
+void SUnicodeCharacterInfo::SetRow(TSharedPtr<FUnicodeBrowserRow> InRow)
+{
+	Row = InRow;
+	Invalidate(EInvalidateWidgetReason::PaintAndVolatility);
+}
+
+END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/Source/UnicodeBrowser/Widgets/UnicodeCharacterInfo.cpp
+++ b/Source/UnicodeBrowser/Widgets/UnicodeCharacterInfo.cpp
@@ -12,12 +12,6 @@ BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
 void SUnicodeCharacterInfo::Construct(FArguments const& InArgs)
 {
 	Row = InArgs._Row;
-
-	if(!Row.Get()->GetFontData())
-	{
-		// chicken out if the row doesn't have valid FontData (e.g. the dummy which is generated when spawning the Tool Window)
-		return;
-	}
 	
 	ChildSlot
 	[

--- a/Source/UnicodeBrowser/Widgets/UnicodeCharacterInfo.h
+++ b/Source/UnicodeBrowser/Widgets/UnicodeCharacterInfo.h
@@ -1,0 +1,26 @@
+// all rights reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UnicodeBrowser/UnicodeBrowserWidget.h"
+#include "Widgets/SCompoundWidget.h"
+
+/**
+ * 
+ */
+class UNICODEBROWSER_API SUnicodeCharacterInfo : public SCompoundWidget
+{
+
+public:
+	SLATE_BEGIN_ARGS(SUnicodeCharacterInfo) {}
+	SLATE_ATTRIBUTE(TSharedPtr<FUnicodeBrowserRow>, Row);
+	SLATE_END_ARGS()
+
+	void Construct(FArguments const& InArgs);
+	
+	TAttribute<TSharedPtr<FUnicodeBrowserRow>> Row;
+	TSharedPtr<FUnicodeBrowserRow> GetRow() const;
+	
+	void SetRow(TSharedPtr<FUnicodeBrowserRow> InRow);
+};


### PR DESCRIPTION
the options post property changed delegate is now one function which repopulates the character list and the grid panels (instead of each grid panel doing it's own thing)

filtering is now done on options change (this was just more convenient to do for me right now, and it skips the measurement calculation when it's not necessary)

most things which are tied to a specific range are now in a TMap<EUnicodeBlockRange, foobar> for easier access

When changing options/font it now picks the ranges based on the Ranges which have entries (this hides all empty categories by default)

todo: the PostPropertyChanged delegate should probably be a bit smarter and only repopulate characters when the font/filter changes