### PR TITLE
Refactor, cleanup, Zoom

### DIFF
--- a/Source/UnicodeBrowser/UnicodeBrowserRow.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserRow.h
@@ -77,13 +77,13 @@ public:
 
 	// preload cached data
 	void Preload() const
-	{
+	{		
+		// ReSharper disable once CppExpressionWithoutSideEffects
+		GetFontData();
 		// ReSharper disable once CppExpressionWithoutSideEffects
 		GetMeasurements();
 		// ReSharper disable once CppExpressionWithoutSideEffects
 		CanLoadCodepoint();
-		// ReSharper disable once CppExpressionWithoutSideEffects
-		GetFontData();
 	}
 
 	friend bool operator==(FUnicodeBrowserRow const& Lhs, FUnicodeBrowserRow const& RHS)

--- a/Source/UnicodeBrowser/UnicodeBrowserStatic.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserStatic.cpp
@@ -1,0 +1,63 @@
+#include "UnicodeBrowserWidget.h"
+
+THIRD_PARTY_INCLUDES_START
+#include <unicode/uchar.h>
+#include <unicode/unistr.h>
+THIRD_PARTY_INCLUDES_END
+
+TOptional<EUnicodeBlockRange> UnicodeBrowser::GetUnicodeBlockRangeFromChar(int32 const CharCode)
+{
+	for (auto const& BlockRange : FUnicodeBlockRange::GetUnicodeBlockRanges())
+	{
+		if (BlockRange.Range.Contains(CharCode))
+		{
+			return BlockRange.Index;
+		}
+	}
+	UE_LOG(LogTemp, Warning, TEXT("No Unicode block range found for character code U+%-06.04X: %s"), CharCode, *FString::Chr(CharCode));
+	return {};
+}
+
+TArrayView<FUnicodeBlockRange const> UnicodeBrowser::GetUnicodeBlockRanges()
+{
+	auto BlockRange = FUnicodeBlockRange::GetUnicodeBlockRanges();
+	BlockRange.StableSort(
+		[](FUnicodeBlockRange const& A, FUnicodeBlockRange const& B)
+		{
+			return A.DisplayName.CompareTo(B.DisplayName) < 0;
+		}
+	);
+	return BlockRange;
+}
+
+int32 UnicodeBrowser::GetRangeIndex(EUnicodeBlockRange BlockRange)
+{
+	return GetUnicodeBlockRanges().IndexOfByPredicate(
+		[BlockRange](FUnicodeBlockRange const& Range)
+		{
+			return Range.Index == BlockRange;
+		}
+	);
+}
+
+FString UnicodeBrowser::GetUnicodeCharacterName(int32 const CharCode)
+{
+	UChar32 const uChar = static_cast<UChar32>(CharCode);
+	UErrorCode errorCode = U_ZERO_ERROR;
+	char* name = new char[256];
+
+	// Get the Unicode character name using ICU
+	int32_t const length = u_charName(uChar, U_CHAR_NAME_ALIAS, name, 256, &errorCode);
+	FString Result;
+	if (U_SUCCESS(errorCode) && length > 0)
+	{
+		Result = FString(name);
+	}
+	else
+	{
+		Result = FString::Printf(TEXT("Unknown %hs"), u_errorName(errorCode));
+	}
+	delete[] name;
+	return Result;
+}
+

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
@@ -539,7 +539,7 @@ void SUnicodeBrowserWidget::PopulateSupportedCharacters()
 	}
 }
 
-FString SUnicodeBrowserWidget::GetUnicodeCharacterName(int32 const CharCode)
+FString UnicodeBrowser::GetUnicodeCharacterName(int32 const CharCode)
 {
 	UChar32 const uChar = static_cast<UChar32>(CharCode);
 	UErrorCode errorCode = U_ZERO_ERROR;

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
@@ -381,7 +381,7 @@ void SUnicodeBrowserWidget::Construct(FArguments const& InArgs)
 
 void SUnicodeBrowserWidget::HandleZoomFont(float Offset)
 {	
-	Options->FontInfo.Size += Offset;
+	Options->FontInfo.Size = FMath::Max(1.0f, Options->FontInfo.Size + Offset);
 
 	// update each entry with the new fontsize
 	for(auto &[Range, RangeWidget] : RangeWidgets)
@@ -396,7 +396,7 @@ void SUnicodeBrowserWidget::HandleZoomFont(float Offset)
 void SUnicodeBrowserWidget::HandleZoomColumns(float Offset)
 {
 	// we want inverted behavior for columns
-	Options->NumCols -= Offset;
+	Options->NumCols = FMath::Max(1, FMath::RoundToInt(Options->NumCols - Offset));
 	
 	RebuildGrid();
 }

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
@@ -24,47 +24,9 @@
 #include "Widgets/Layout/SUniformGridPanel.h"
 #include "Widgets/Text/STextBlock.h"
 
-THIRD_PARTY_INCLUDES_START
-#include <unicode/uchar.h>
-#include <unicode/unistr.h>
-THIRD_PARTY_INCLUDES_END
+
 
 BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
-
-TOptional<EUnicodeBlockRange> UnicodeBrowser::GetUnicodeBlockRangeFromChar(int32 const CharCode)
-{
-	for (auto const& BlockRange : FUnicodeBlockRange::GetUnicodeBlockRanges())
-	{
-		if (BlockRange.Range.Contains(CharCode))
-		{
-			return BlockRange.Index;
-		}
-	}
-	UE_LOG(LogTemp, Warning, TEXT("No Unicode block range found for character code U+%-06.04X: %s"), CharCode, *FString::Chr(CharCode));
-	return {};
-}
-
-TArrayView<FUnicodeBlockRange const> UnicodeBrowser::GetUnicodeBlockRanges()
-{
-	auto BlockRange = FUnicodeBlockRange::GetUnicodeBlockRanges();
-	BlockRange.StableSort(
-		[](FUnicodeBlockRange const& A, FUnicodeBlockRange const& B)
-		{
-			return A.DisplayName.CompareTo(B.DisplayName) < 0;
-		}
-	);
-	return BlockRange;
-}
-
-int32 UnicodeBrowser::GetRangeIndex(EUnicodeBlockRange BlockRange)
-{
-	return GetUnicodeBlockRanges().IndexOfByPredicate(
-		[BlockRange](FUnicodeBlockRange const& Range)
-		{
-			return Range.Index == BlockRange;
-		}
-	);
-}
 
 TSharedPtr<SUbCheckBoxList> SUnicodeBrowserWidget::MakeBlockRangeSelector()
 {
@@ -537,27 +499,6 @@ void SUnicodeBrowserWidget::PopulateSupportedCharacters()
 			}
 		}
 	}
-}
-
-FString UnicodeBrowser::GetUnicodeCharacterName(int32 const CharCode)
-{
-	UChar32 const uChar = static_cast<UChar32>(CharCode);
-	UErrorCode errorCode = U_ZERO_ERROR;
-	char* name = new char[256];
-
-	// Get the Unicode character name using ICU
-	int32_t const length = u_charName(uChar, U_CHAR_NAME_ALIAS, name, 256, &errorCode);
-	FString Result;
-	if (U_SUCCESS(errorCode) && length > 0)
-	{
-		Result = FString(name);
-	}
-	else
-	{
-		Result = FString::Printf(TEXT("Unknown %hs"), u_errorName(errorCode));
-	}
-	delete[] name;
-	return Result;
 }
 
 END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.cpp
@@ -14,6 +14,7 @@
 #include "Modules/ModuleManager.h"
 
 #include "UnicodeBrowser/Widgets/SUbCheckBoxList.h"
+#include "Widgets/SUnicodeCharacterGridEntry.h"
 #include "Widgets/SUnicodeRangeWidget.h"
 
 #include "Widgets/UnicodeCharacterInfo.h"
@@ -122,28 +123,11 @@ void SUnicodeBrowserWidget::RebuildGrid(FUnicodeBlockRange const Range, TSharedR
 		if (!RowEntries.IsValidIndex(i)) continue;
 
 		auto const Row = RowEntries[i];
-		TSharedPtr<SCompoundWidget> GridCell;
-		if (!RowCellWidgetCache.Contains(Row->Codepoint))
-		{
-			GridCell = SNew(SBorder)
-				.BorderImage(nullptr)
-				.OnMouseMove(this, &SUnicodeBrowserWidget::OnCharacterMouseMove, Row)
-				[
-					SNew(STextBlock)
-					.Font(this, &SUnicodeBrowserWidget::GetFontInfo)
-					.IsEnabled(true)
-					.Justification(ETextJustify::Center)
-					.Text(FText::FromString(FString::Printf(TEXT("%s"), *Row->Character)))
-					.ToolTipText(FText::FromString(FString::Printf(TEXT("Char Code: U+%-06.04X. Double-Click to copy: %s."), Row->Codepoint, *Row->Character)))
-					.OnDoubleClicked(this, &SUnicodeBrowserWidget::OnCharacterClicked, Row->Character)
-				];
-
-			RowCellWidgetCache.Add(Row->Codepoint, GridCell.ToSharedRef());
-		}
-		else
-		{
-			GridCell = RowCellWidgetCache[Row->Codepoint];
-		}
+		TSharedPtr<SUnicodeCharacterGridEntry> GridCell = SNew(SUnicodeCharacterGridEntry)
+				.FontInfo(GetFontInfo())
+				.UnicodeCharacter(Row)
+				.OnMouseDoubleClick(this, &SUnicodeBrowserWidget::OnCharacterClicked, Row->Character)
+				.OnMouseMove(this, &SUnicodeBrowserWidget::OnCharacterMouseMove, Row);
 
 		Slot
 		[

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -9,6 +9,7 @@
 #include "Fonts/UnicodeBlockRange.h"
 
 #include "Widgets/SCompoundWidget.h"
+#include "Widgets/SUnicodeRangeWidget.h"
 #include "Widgets/Views/SListView.h"
 
 class SExpandableArea;
@@ -70,8 +71,7 @@ protected:
 	TArrayView<FUnicodeBlockRange const> Ranges; // all known Unicode ranges
 	TMap<EUnicodeBlockRange const, int32 const> CheckboxIndices; // range <> SUbCheckBoxList index 
 	TMap<EUnicodeBlockRange, TArray<TSharedPtr<FUnicodeBrowserRow>>> Rows;
-	TMap<EUnicodeBlockRange, TSharedPtr<SExpandableArea>> RangeWidgets;
-	TMap<EUnicodeBlockRange, TSharedPtr<SUniformGridPanel>> RangeWidgetsGrid;
+	TMap<EUnicodeBlockRange, TSharedPtr<SUnicodeRangeWidget>> RangeWidgets;
 	TObjectPtr<UUnicodeBrowserOptions> Options;
 	TSharedPtr<IDetailsView> FontDetailsView;
 	TSharedPtr<SScrollBox> RangeScrollbox;
@@ -97,7 +97,6 @@ protected:
 	TSharedPtr<SExpandableArea> MakeBlockRangesSidebar();
 	TSharedPtr<SUbCheckBoxList> MakeBlockRangeSelector();
 
-	void MakeRangeWidget(FUnicodeBlockRange Range);
 	void PopulateSupportedCharacters();
 	void RebuildGrid(FUnicodeBlockRange Range, TSharedRef<SUniformGridPanel> const GridPanel) const;
 	void UpdateFromFont(FPropertyChangedEvent* PropertyChangedEvent = nullptr);

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -22,6 +22,8 @@ namespace UnicodeBrowser
 {
 	TCHAR constexpr InvalidSubChar = TEXT('\uFFFD');
 	TOptional<EUnicodeBlockRange> GetUnicodeBlockRangeFromChar(int32 const CharCode);
+	
+	static FString GetUnicodeCharacterName(int32 CharCode);
 
 	TArrayView<FUnicodeBlockRange const> GetUnicodeBlockRanges();
 
@@ -91,7 +93,6 @@ protected:
 	FReply OnCharacterMouseMove(FGeometry const& Geometry, FPointerEvent const& PointerEvent, TSharedPtr<FUnicodeBrowserRow> Row) const;
 
 	FSlateFontInfo GetFontInfo() const;
-	static FString GetUnicodeCharacterName(int32 CharCode);
 
 	TSharedPtr<SExpandableArea> MakeBlockRangesSidebar();
 	TSharedPtr<SUbCheckBoxList> MakeBlockRangeSelector();

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -91,15 +91,19 @@ protected:
 	void MarkDirty();
 	FReply OnRangeClicked(EUnicodeBlockRange BlockRange) const;
 	FReply OnCharacterMouseMove(FGeometry const& Geometry, FPointerEvent const& PointerEvent, TSharedPtr<FUnicodeBrowserRow> Row) const;
-
+	void HandleZoomFont(float Offset);
+	void HandleZoomColumns(float Offset);
+	void HandleFontChanged();
+	
 	FSlateFontInfo GetFontInfo() const;
 
 	TSharedPtr<SExpandableArea> MakeBlockRangesSidebar();
 	TSharedPtr<SUbCheckBoxList> MakeBlockRangeSelector();
 
 	void PopulateSupportedCharacters();
-	void RebuildGrid(FUnicodeBlockRange Range, TSharedRef<SUniformGridPanel> const GridPanel) const;
+	void RebuildGridRange(TSharedPtr<SUnicodeRangeWidget> RangeWidget) const;
 	void UpdateFromFont(FPropertyChangedEvent* PropertyChangedEvent = nullptr);
 	void SelectAllRangesWithCharacters() const;
+	void RebuildGrid();
 };
 

--- a/Source/UnicodeBrowser/UnicodeBrowserWidget.h
+++ b/Source/UnicodeBrowser/UnicodeBrowserWidget.h
@@ -9,6 +9,7 @@
 #include "Fonts/UnicodeBlockRange.h"
 
 #include "Widgets/SCompoundWidget.h"
+#include "Widgets/SUnicodeCharacterGridEntry.h"
 #include "Widgets/SUnicodeRangeWidget.h"
 #include "Widgets/Views/SListView.h"
 
@@ -79,7 +80,6 @@ protected:
 	TSharedPtr<SUbCheckBoxList> RangeSelector;
 	TSharedPtr<SExpandableArea> BlockRangesSidebar;
 	bool bDirty = true;
-	mutable TMap<int32, TSharedRef<SCompoundWidget>> RowCellWidgetCache;
 	mutable TSharedPtr<FUnicodeBrowserRow> CurrentRow;
 
 protected:

--- a/Source/UnicodeBrowser/Widgets/SUnicodeCharacterGridEntry.cpp
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeCharacterGridEntry.cpp
@@ -1,0 +1,36 @@
+// all rights reserved
+
+
+#include "SUnicodeCharacterGridEntry.h"
+
+#include "SlateOptMacros.h"
+
+BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
+
+void SUnicodeCharacterGridEntry::Construct(const FArguments& InArgs)
+{
+	UnicodeCharacter = InArgs._UnicodeCharacter.Get();
+
+	SBorder::Construct(SBorder::FArguments()
+		.BorderImage(nullptr)
+		.OnMouseMove(InArgs._OnMouseMove)
+		.OnMouseDoubleClick(InArgs._OnMouseDoubleClick));
+	
+	if(!UnicodeCharacter)
+	{
+		UE_LOG(LogTemp, Error, TEXT("[SUnicodeCharacterGridEntry::Construct] Widget created without valid CharacterRow pointer"));
+		return;
+	}
+	
+	ChildSlot [
+		SNew(STextBlock)
+			.Font(InArgs._FontInfo)
+			.IsEnabled(true)
+			.Justification(ETextJustify::Center)
+			.Text(FText::FromString(FString::Printf(TEXT("%s"), *UnicodeCharacter->Character)))
+			.ToolTipText(FText::FromString(FString::Printf(TEXT("Char Code: U+%-06.04X. Double-Click to copy: %s."), UnicodeCharacter->Codepoint, *UnicodeCharacter->Character)))
+		];
+	
+}
+
+END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/Source/UnicodeBrowser/Widgets/SUnicodeCharacterGridEntry.cpp
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeCharacterGridEntry.cpp
@@ -23,7 +23,7 @@ void SUnicodeCharacterGridEntry::Construct(const FArguments& InArgs)
 	}
 	
 	ChildSlot [
-		SNew(STextBlock)
+		SAssignNew(TextBlock, STextBlock)
 			.Font(InArgs._FontInfo)
 			.IsEnabled(true)
 			.Justification(ETextJustify::Center)
@@ -31,6 +31,11 @@ void SUnicodeCharacterGridEntry::Construct(const FArguments& InArgs)
 			.ToolTipText(FText::FromString(FString::Printf(TEXT("Char Code: U+%-06.04X. Double-Click to copy: %s."), UnicodeCharacter->Codepoint, *UnicodeCharacter->Character)))
 		];
 	
+}
+
+void SUnicodeCharacterGridEntry::SetFontInfo(FSlateFontInfo& FontInfoIn)
+{
+	TextBlock->SetFont(FontInfoIn);
 }
 
 END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/Source/UnicodeBrowser/Widgets/SUnicodeCharacterGridEntry.h
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeCharacterGridEntry.h
@@ -26,6 +26,9 @@ public:
 	/** Constructs this widget with InArgs */
 	void Construct(const FArguments& InArgs);
 
+	void SetFontInfo(FSlateFontInfo &FontInfoIn);
+
 private:
 	TSharedPtr<FUnicodeBrowserRow> UnicodeCharacter;
+	TSharedPtr<STextBlock> TextBlock;
 };

--- a/Source/UnicodeBrowser/Widgets/SUnicodeCharacterGridEntry.h
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeCharacterGridEntry.h
@@ -1,0 +1,31 @@
+// all rights reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UnicodeBrowser/UnicodeBrowserRow.h"
+#include "Widgets/SCompoundWidget.h"
+
+/**
+ * 
+ */
+class UNICODEBROWSER_API SUnicodeCharacterGridEntry : public SBorder
+{
+public:
+	SLATE_BEGIN_ARGS(SUnicodeCharacterGridEntry)
+		{}
+	SLATE_ARGUMENT(SBorder::FArguments, ParentArgs)
+	SLATE_ARGUMENT(FSlateFontInfo, FontInfo)
+	SLATE_ATTRIBUTE(TSharedPtr<FUnicodeBrowserRow>, UnicodeCharacter)
+
+	SLATE_EVENT(FPointerEventHandler, OnMouseMove)
+	SLATE_EVENT(FPointerEventHandler, OnMouseDoubleClick) 
+	
+	SLATE_END_ARGS()
+
+	/** Constructs this widget with InArgs */
+	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedPtr<FUnicodeBrowserRow> UnicodeCharacter;
+};

--- a/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.cpp
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.cpp
@@ -1,0 +1,36 @@
+// all rights reserved
+
+
+#include "SUnicodeRangeWidget.h"
+
+#include "SlateOptMacros.h"
+#include "Widgets/Layout/SScaleBox.h"
+
+BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
+
+void SUnicodeRangeWidget::Construct(const FArguments& InArgs)
+{
+	Range = InArgs._Range.Get();
+
+	SExpandableArea::Construct(SExpandableArea::FArguments()
+		.HeaderPadding(FMargin(2, 4))
+		.HeaderContent()
+		[
+			SNew(STextBlock)
+			.Text(Range.DisplayName)
+		]
+		.BodyContent()
+		[
+			SNew(SScaleBox)
+			.Stretch(EStretch::ScaleToFit)
+			.HAlign(HAlign_Fill)
+			.VAlign(VAlign_Fill)
+			[
+				SAssignNew(GridPanel, SUniformGridPanel)
+				.SlotPadding(FMargin(6.f, 4.f))
+			]
+		]
+	);
+}
+
+END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.cpp
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.cpp
@@ -11,26 +11,53 @@ BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
 void SUnicodeRangeWidget::Construct(const FArguments& InArgs)
 {
 	Range = InArgs._Range.Get();
+	OnZoomFontSize = InArgs._OnZoomFontSize;
+	OnZoomColumnCount = InArgs._OnZoomColumnCount;
+	
+	SBorder::Construct(SBorder::FArguments());
 
-	SExpandableArea::Construct(SExpandableArea::FArguments()
-		.HeaderPadding(FMargin(2, 4))
-		.HeaderContent()
-		[
-			SNew(STextBlock)
-			.Text(Range.DisplayName)
-		]
-		.BodyContent()
-		[
-			SNew(SScaleBox)
-			.Stretch(EStretch::ScaleToFit)
-			.HAlign(HAlign_Fill)
-			.VAlign(VAlign_Fill)
+	ChildSlot [
+		SNew(SExpandableArea)
+			.HeaderPadding(FMargin(2, 4))
+			.HeaderContent()
 			[
-				SAssignNew(GridPanel, SUniformGridPanel)
-				.SlotPadding(FMargin(6.f, 4.f))
+				SNew(STextBlock)
+				.Text(Range.DisplayName)
 			]
-		]
-	);
+			.BodyContent()
+			[
+				SNew(SScaleBox)
+				.Stretch(EStretch::ScaleToFit)
+				.HAlign(HAlign_Fill)
+				.VAlign(VAlign_Fill)
+				[
+					SAssignNew(GridPanel, SUniformGridPanel)
+					.SlotPadding(FMargin(6.f, 4.f))
+				]
+			]	
+	];
+}
+
+FReply SUnicodeRangeWidget::OnMouseWheel(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent)
+{
+	if(MouseEvent.GetWheelDelta() && MouseEvent.IsControlDown())
+	{
+		// CTRL + !Shift => Zoom Font
+		if(!MouseEvent.IsShiftDown() && OnZoomFontSize.IsBound())
+		{
+			OnZoomFontSize.Execute(MouseEvent.GetWheelDelta());			
+			return FReply::Handled();
+		}
+
+		// CTRL + Shift => Zoom Columns
+		if(MouseEvent.IsShiftDown() && OnZoomColumnCount.IsBound())
+		{
+			OnZoomColumnCount.Execute(MouseEvent.GetWheelDelta());			
+			return FReply::Handled();
+		}
+	}
+
+	return FReply::Unhandled();
 }
 
 END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.h
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.h
@@ -15,7 +15,6 @@ class UNICODEBROWSER_API SUnicodeRangeWidget : public SExpandableArea
 public:
 	SLATE_BEGIN_ARGS(SUnicodeRangeWidget)
 		{}
-	//SLATE_ARGUMENT(SExpandableArea::FArguments, ParentArgs) 
 	SLATE_ATTRIBUTE(FUnicodeBlockRange, Range);
 	SLATE_END_ARGS()
 

--- a/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.h
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "SUnicodeCharacterGridEntry.h"
 #include "Fonts/UnicodeBlockRange.h"
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/Layout/SUniformGridPanel.h"
@@ -10,14 +11,19 @@
 /**
  * 
  */
-class UNICODEBROWSER_API SUnicodeRangeWidget : public SExpandableArea
+class UNICODEBROWSER_API SUnicodeRangeWidget : public SBorder
 {
 public:
+	DECLARE_DELEGATE_OneParam(FZoomEvent, float Offset)
+	
 	SLATE_BEGIN_ARGS(SUnicodeRangeWidget)
 		{}
 	SLATE_ATTRIBUTE(FUnicodeBlockRange, Range);
+	SLATE_EVENT(FZoomEvent, OnZoomFontSize)
+	SLATE_EVENT(FZoomEvent, OnZoomColumnCount)
 	SLATE_END_ARGS()
 
+	TArray<TSharedPtr<SUnicodeCharacterGridEntry>> Characters;
 
 	/** Constructs this widget with InArgs */
 	void Construct(const FArguments& InArgs);
@@ -26,7 +32,11 @@ public:
 
 	TSharedRef<SUniformGridPanel> GetGridPanel() const { return GridPanel.ToSharedRef(); };
 	
+	virtual FReply OnMouseWheel(const FGeometry& MyGeometry, const FPointerEvent& MouseEvent) override;;
+	
 private:
 	FUnicodeBlockRange Range = FUnicodeBlockRange(EUnicodeBlockRange::ControlCharacter, INVTEXT("default"), FInt32Range(0, 1));
 	TSharedPtr<SUniformGridPanel> GridPanel;
+	FZoomEvent OnZoomFontSize;
+	FZoomEvent OnZoomColumnCount;
 };

--- a/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.h
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeRangeWidget.h
@@ -1,0 +1,33 @@
+// all rights reserved
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Fonts/UnicodeBlockRange.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/Layout/SUniformGridPanel.h"
+
+/**
+ * 
+ */
+class UNICODEBROWSER_API SUnicodeRangeWidget : public SExpandableArea
+{
+public:
+	SLATE_BEGIN_ARGS(SUnicodeRangeWidget)
+		{}
+	//SLATE_ARGUMENT(SExpandableArea::FArguments, ParentArgs) 
+	SLATE_ATTRIBUTE(FUnicodeBlockRange, Range);
+	SLATE_END_ARGS()
+
+
+	/** Constructs this widget with InArgs */
+	void Construct(const FArguments& InArgs);
+
+	FUnicodeBlockRange GetRange() const { return Range; }
+
+	TSharedRef<SUniformGridPanel> GetGridPanel() const { return GridPanel.ToSharedRef(); };
+	
+private:
+	FUnicodeBlockRange Range = FUnicodeBlockRange(EUnicodeBlockRange::ControlCharacter, INVTEXT("default"), FInt32Range(0, 1));
+	TSharedPtr<SUniformGridPanel> GridPanel;
+};


### PR DESCRIPTION
moved a bunch of stuff outside of the main Widget class, e.g. all name space methods are defined in their own cpp file now. 
Added "standalone" Widgets for the ExpandableArea which handles a range, and for the CharacterEntries within that area.

new zoom feature:
CTRL + MouseWheel => Zooms Font Size
CTRL + SHIFT + MouseWheel => Changes Column count
