### PR TITLE
Update SUnicodeBlockRangeSelector.cpp

### DIFF
--- a/Source/UnicodeBrowser/Widgets/SUnicodeBlockRangeSelector.cpp
+++ b/Source/UnicodeBrowser/Widgets/SUnicodeBlockRangeSelector.cpp
@@ -106,15 +106,19 @@ void SUnicodeBlockRangeSelector::SetRanges(TArray<EUnicodeBlockRange> const& Ran
 			continue;
 		}
 
-		if (CheckboxIndices[Range.Index], RangesToSet.Contains(Range.Index))
+		int32 const ItemIndex = CheckboxIndices[Range.Index];
+		
+		if (ItemIndex, RangesToSet.Contains(Range.Index))
 		{
-			CheckBoxList->SetItemChecked(CheckboxIndices[Range.Index], ECheckBoxState::Checked);
+			
+			CheckBoxList->SetItemChecked(ItemIndex, ECheckBoxState::Checked);
 		}
 		else if (bExclusive)
 		{
-			CheckBoxList->SetItemChecked(CheckboxIndices[Range.Index], ECheckBoxState::Unchecked);
+			CheckBoxList->SetItemChecked(ItemIndex, ECheckBoxState::Unchecked);
 		}
 	}
+}
 }
 
 void SUnicodeBlockRangeSelector::Tick(FGeometry const& AllottedGeometry, double const InCurrentTime, float const InDeltaTime)


### PR DESCRIPTION
Fixing the following error found when compiling for UE5.6.

0>SUnicodeBlockRangeSelector.cpp(109,34): Error C4834 : discarding return value of function with [[nodiscard]] attribute 0>		if (CheckboxIndices[Range.Index], RangesToSet.Contains(Range.Index))
0>		                               ^